### PR TITLE
refactor(templat-string-parser): align token names to the spec

### DIFF
--- a/src/stamped-template.ts
+++ b/src/stamped-template.ts
@@ -35,10 +35,10 @@ function* collectParts(el: DocumentFragment): Generator<Part> {
             if (token.end < value.length) {
               const oldPart = part
               part = part.split(token.end - token.start)
-              if (token.type === 'expr') {
+              if (token.type === 'part') {
                 yield new Part(node, oldPart, token.value)
               }
-            } else if (token.type === 'expr') {
+            } else if (token.type === 'part') {
               yield new Part(node, part, token.value)
             }
           }
@@ -47,7 +47,7 @@ function* collectParts(el: DocumentFragment): Generator<Part> {
     } else if (node instanceof Text && node.textContent && node.textContent.includes('{{')) {
       for (const token of parse(node.textContent)) {
         if (token.end < node.textContent.length) node.splitText(token.end)
-        if (token.type === 'expr') yield new Part(node, node, token.value)
+        if (token.type === 'part') yield new Part(node, node, token.value)
         break
       }
     }

--- a/src/template-string-parser.ts
+++ b/src/template-string-parser.ts
@@ -1,16 +1,16 @@
-interface TextToken {
-  type: 'text'
+interface StringToken {
+  type: 'string'
   start: number
   end: number
   value: string
 }
-interface ExprToken {
-  type: 'expr'
+interface PartToken {
+  type: 'part'
   start: number
   end: number
   value: string
 }
-export type Token = TextToken | ExprToken
+export type Token = StringToken | PartToken
 export function* parse(text: string): Iterable<Token> {
   let value = ''
   let tokenStart = 0
@@ -18,18 +18,18 @@ export function* parse(text: string): Iterable<Token> {
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === '{' && text[i + 1] === '{' && !open) {
       open = true
-      if (value) yield {type: 'text', start: tokenStart, end: i, value}
+      if (value) yield {type: 'string', start: tokenStart, end: i, value}
       value = '{{'
       tokenStart = i
       i += 2
     } else if (text[i] === '}' && text[i + 1] === '}' && open) {
       open = false
-      yield {type: 'expr', start: tokenStart, end: i + 2, value: value.slice(2)}
+      yield {type: 'part', start: tokenStart, end: i + 2, value: value.slice(2)}
       value = ''
       i += 2
       tokenStart = i
     }
     value += text[i] || ''
   }
-  if (value) yield {type: 'text', start: tokenStart, end: text.length, value}
+  if (value) yield {type: 'string', start: tokenStart, end: text.length, value}
 }

--- a/test/template-string-parser.js
+++ b/test/template-string-parser.js
@@ -1,35 +1,35 @@
 import {parse} from '../lib/template-string-parser.js'
 
 describe('template-string-parser', () => {
-  it('extracts `{{}}` surrounding exprs as expr tokens', () => {
-    expect(Array.from(parse('{{x}}'))).to.eql([{type: 'expr', start: 0, end: 5, value: 'x'}])
+  it('extracts `{{}}` surrounding parts as expr tokens', () => {
+    expect(Array.from(parse('{{x}}'))).to.eql([{type: 'part', start: 0, end: 5, value: 'x'}])
   })
 
   it('tokenizes a template string successfully', () => {
     expect(Array.from(parse('hello {{x}}'))).to.eql([
-      {type: 'text', start: 0, end: 6, value: 'hello '},
-      {type: 'expr', start: 6, end: 11, value: 'x'}
+      {type: 'string', start: 0, end: 6, value: 'hello '},
+      {type: 'part', start: 6, end: 11, value: 'x'}
     ])
   })
 
   it('tokenizes multiple values', () => {
     expect(Array.from(parse('hello {{x}} and {{y}}'))).to.eql([
-      {type: 'text', start: 0, end: 6, value: 'hello '},
-      {type: 'expr', start: 6, end: 11, value: 'x'},
-      {type: 'text', start: 11, end: 16, value: ' and '},
-      {type: 'expr', start: 16, end: 21, value: 'y'}
+      {type: 'string', start: 0, end: 6, value: 'hello '},
+      {type: 'part', start: 6, end: 11, value: 'x'},
+      {type: 'string', start: 11, end: 16, value: ' and '},
+      {type: 'part', start: 16, end: 21, value: 'y'}
     ])
   })
 
   it('ignores single braces', () => {
-    expect(Array.from(parse('hello ${world?}'))).to.eql([{type: 'text', start: 0, end: 15, value: 'hello ${world?}'}])
+    expect(Array.from(parse('hello ${world?}'))).to.eql([{type: 'string', start: 0, end: 15, value: 'hello ${world?}'}])
   })
 
   it('ignores mismatching parens, treating them as text', () => {
     expect(Array.from(parse('hello {{'))).to.eql([
-      {type: 'text', start: 0, end: 6, value: 'hello '},
-      {type: 'text', start: 6, end: 8, value: '{{'}
+      {type: 'string', start: 0, end: 6, value: 'hello '},
+      {type: 'string', start: 6, end: 8, value: '{{'}
     ])
-    expect(Array.from(parse('hello }}'))).to.eql([{type: 'text', start: 0, end: 8, value: 'hello }}'}])
+    expect(Array.from(parse('hello }}'))).to.eql([{type: 'string', start: 0, end: 8, value: 'hello }}'}])
   })
 })


### PR DESCRIPTION
This aligns us a bit closer to the [spec](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md#31-basics), it makes no functional difference though.