### PR TITLE
style: fix `update()` type

### DIFF
--- a/src/template-instance.ts
+++ b/src/template-instance.ts
@@ -52,7 +52,7 @@ export class TemplateInstance extends DocumentFragment {
     this.#processor.createCallback?.(this, this.#parts, params)
   }
 
-  update(params: Record<string, unknown>): void {
+  update(params: unknown): void {
     this.#processor.processCallback(this, this.#parts, params)
   }
 }


### PR DESCRIPTION
The type for `update` is necessarily defined as `Record<string, unknown>` while the processor types and constructor type is defined as `unknown`.

This updates the `update` call to also take an `unknown` for symmetry in all types.