### PR TITLE
feat: add createProcessor for simple processor creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,11 @@ export {TemplateInstance} from './template-instance.js'
 export {parse} from './template-string-parser.js'
 export {AttributeTemplatePart, AttributeValueSetter} from './attribute-template-part.js'
 export {NodeTemplatePart} from './node-template-part.js'
-export {propertyIdentity, propertyIdentityOrBooleanAttribute} from './processors.js'
+export {
+  createProcessor,
+  processPropertyIdentity,
+  processBooleanAttribute,
+  propertyIdentity,
+  propertyIdentityOrBooleanAttribute
+} from './processors.js'
 export type {TemplatePart, TemplateTypeInit} from './types.js'

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -1,38 +1,39 @@
-import type {TemplatePart} from './types.js'
+import type {TemplatePart, TemplateTypeInit} from './types.js'
 import type {TemplateInstance} from './template-instance.js'
 import {AttributeTemplatePart} from './attribute-template-part.js'
 
-export const propertyIdentity = {
-  createCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
-    this.processCallback(instance, parts, params)
-  },
-  processCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
-    if (typeof params !== 'object' || !params) return
-    for (const part of parts) {
-      if (!(part.expression in params)) continue
-      part.value = String((params as Record<string, unknown>)[part.expression] ?? '')
+type PartProcessor = (part: TemplatePart, params: unknown) => void
+
+export function createProcessor(processPart: PartProcessor): TemplateTypeInit {
+  return {
+    createCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
+      this.processCallback(instance, parts, params)
+    },
+    processCallback(_: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
+      if (typeof params !== 'object' || !params) return
+      for (const part of parts) if (part.expression in params) processPart(part, params)
     }
   }
 }
 
-export const propertyIdentityOrBooleanAttribute = {
-  createCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
-    this.processCallback(instance, parts, params)
-  },
-  processCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
-    if (typeof params !== 'object' || !params) return
-    for (const part of parts) {
-      if (!(part.expression in params)) continue
-      const value = (params as Record<string, unknown>)[part.expression] ?? ''
-      if (
-        typeof value === 'boolean' &&
-        part instanceof AttributeTemplatePart &&
-        typeof part.element[part.attributeName as keyof Element] === 'boolean'
-      ) {
-        part.booleanValue = value
-      } else {
-        part.value = String(value)
-      }
-    }
-  }
+export function processPropertyIdentity(part: TemplatePart, params: unknown): void {
+  part.value = String((params as Record<string, unknown>)[part.expression] ?? '')
 }
+
+export function processBooleanAttribute(part: TemplatePart, params: unknown): boolean {
+  const value = (params as Record<string, unknown>)[part.expression] ?? ''
+  if (
+    typeof value === 'boolean' &&
+    part instanceof AttributeTemplatePart &&
+    typeof part.element[part.attributeName as keyof Element] === 'boolean'
+  ) {
+    part.booleanValue = value
+    return true
+  }
+  return false
+}
+
+export const propertyIdentity = createProcessor(processPropertyIdentity)
+export const propertyIdentityOrBooleanAttribute = createProcessor((part: TemplatePart, params: unknown) => {
+  processBooleanAttribute(part, params) || processPropertyIdentity(part, params)
+})

--- a/test/processors.js
+++ b/test/processors.js
@@ -1,0 +1,30 @@
+import {TemplateInstance} from '../lib/template-instance.js'
+import {createProcessor} from '../lib/processors.js'
+describe('createProcessor', () => {
+  let calls = 0
+  let processor
+  let template
+  const originalHTML = `Hello {{x}}!`
+  beforeEach(() => {
+    calls = 0
+    processor = createProcessor(() => (calls += 1))
+    template = document.createElement('template')
+    template.innerHTML = originalHTML
+  })
+
+  it('creates a processor calling the given function when the param exists', () => {
+    const instance = new TemplateInstance(template, {x: 'world'}, processor)
+    expect(calls).to.eql(1)
+    instance.update({x: 'foo'})
+    expect(calls).to.eql(2)
+    instance.update({})
+    expect(calls).to.eql(2)
+  })
+
+  it('does not process parts with no param for the expression', () => {
+    const instance = new TemplateInstance(template, {}, processor)
+    expect(calls).to.eql(0)
+    instance.update({y: 'world'})
+    expect(calls).to.eql(0)
+  })
+})


### PR DESCRIPTION
This adds a `createProcessor` function/export which can be called with a simple function that receives a single part. These functions can then be composed more easily with simple logical conditions then.

We know our processors all follow this pattern, so this simplifies creation of the processors allowing for code simplification. Any
processor which does not follow this pattern can still be manually created.

This will allow us to make a quite significant reduction in the `jtml` codebase, which duplicates some of this code as it wants to _extend_ the default processor to handle directives.

 Exposing the base part processors and skipping all of this logic allows us to simplify logic in `jtml`.