### PR TITLE
fix(NodeTemplatePart): don't get into bad state with replace()

### DIFF
--- a/src/node-template-part.ts
+++ b/src/node-template-part.ts
@@ -29,6 +29,7 @@ export class NodeTemplatePart implements TemplatePart {
       if (typeof node === 'string') return new Text(node)
       return node
     })
+    if (!parts.length) parts.push(new Text(''))
     this.#parts[0].before(...parts)
     for (const part of this.#parts) part.remove()
     this.#parts = parts

--- a/test/template-instance.js
+++ b/test/template-instance.js
@@ -1,5 +1,5 @@
 import {TemplateInstance} from '../lib/template-instance.js'
-import {propertyIdentityOrBooleanAttribute} from '../lib/processors.js'
+import {propertyIdentityOrBooleanAttribute, createProcessor} from '../lib/processors.js'
 
 describe('template-instance', () => {
   it('applies data to templated text nodes', () => {
@@ -193,6 +193,23 @@ describe('template-instance', () => {
       expect(root.innerHTML).to.equal(`<input aria-disabled="false" hidden="" value="true">`)
       instance.update({b: false})
       expect(root.innerHTML).to.equal(`<input aria-disabled="false" value="false">`)
+    })
+  })
+  
+  describe('edge cases', () => {
+    describe('NodeTemplatePart', () => {
+      it('replaces an empty replace() call with an empty text node', () => {
+        const template = document.createElement('template')
+        template.innerHTML = `<div>{{a}}</div>`
+        const instance = new TemplateInstance(template, {a: true}, createProcessor((part) => {
+          part.replace()
+          part.replace()
+          part.replace()
+        }))
+        const root = document.createElement('div')
+        root.appendChild(instance)
+        expect(root.innerHTML).to.equal(`<div></div>`)
+      })
     })
   })
 })

--- a/test/template-instance.js
+++ b/test/template-instance.js
@@ -195,17 +195,21 @@ describe('template-instance', () => {
       expect(root.innerHTML).to.equal(`<input aria-disabled="false" value="false">`)
     })
   })
-  
+
   describe('edge cases', () => {
     describe('NodeTemplatePart', () => {
       it('replaces an empty replace() call with an empty text node', () => {
         const template = document.createElement('template')
         template.innerHTML = `<div>{{a}}</div>`
-        const instance = new TemplateInstance(template, {a: true}, createProcessor((part) => {
-          part.replace()
-          part.replace()
-          part.replace()
-        }))
+        const instance = new TemplateInstance(
+          template,
+          {a: true},
+          createProcessor(part => {
+            part.replace()
+            part.replace()
+            part.replace()
+          })
+        )
         const root = document.createElement('div')
         root.appendChild(instance)
         expect(root.innerHTML).to.equal(`<div></div>`)


### PR DESCRIPTION
This is a bug spotted while experimenting with this package.

Multiple calls to replace with an empty set of call arguments will cause the `#parts` array to be empty, which means subsequent calls can throw with an hard to debug error of `[0].before() is not a function`.

If a call to replace is empty, then it should replace the contents with an empty text node which it can still use to hook into the DOM to replace subsequent calls, this prevents the error.