### PR TITLE
Memoize parse to improve speed

### DIFF
--- a/src/template-string-parser.ts
+++ b/src/template-string-parser.ts
@@ -17,7 +17,7 @@ export function parse(text: string): readonly Token[] {
   let value = ''
   let tokenStart = 0
   let open = false
-  let items: Token[] = []
+  const items: Token[] = []
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === '{' && text[i + 1] === '{' && text[i - 1] !== '\\' && !open) {
       open = true

--- a/src/template-string-parser.ts
+++ b/src/template-string-parser.ts
@@ -11,25 +11,30 @@ interface PartToken {
   value: string
 }
 export type Token = StringToken | PartToken
-export function* parse(text: string): Iterable<Token> {
+const mem = new Map<string, readonly Token[]>()
+export function parse(text: string): readonly Token[] {
+  if (mem.has(text)) return mem.get(text)!
   let value = ''
   let tokenStart = 0
   let open = false
+  let items: Token[] = []
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === '{' && text[i + 1] === '{' && text[i - 1] !== '\\' && !open) {
       open = true
-      if (value) yield {type: 'string', start: tokenStart, end: i, value}
+      if (value) items.push(Object.freeze({type: 'string', start: tokenStart, end: i, value}))
       value = '{{'
       tokenStart = i
       i += 2
     } else if (text[i] === '}' && text[i + 1] === '}' && text[i - 1] !== '\\' && open) {
       open = false
-      yield {type: 'part', start: tokenStart, end: i + 2, value: value.slice(2).trim()}
+      items.push(Object.freeze({type: 'part', start: tokenStart, end: i + 2, value: value.slice(2).trim()}))
       value = ''
       i += 2
       tokenStart = i
     }
     value += text[i] || ''
   }
-  if (value) yield {type: 'string', start: tokenStart, end: text.length, value}
+  if (value) items.push(Object.freeze({type: 'string', start: tokenStart, end: text.length, value}))
+  mem.set(text, Object.freeze(items))
+  return mem.get(text)!
 }


### PR DESCRIPTION
This changes the `parse` function to no longer return an Iterator, and instead return a Frozen Array of tokens. This also allows us to memoize the call so that calls with repeat data will not be re-parsed and instead return the existing frozen array.

On my machine this results in a 2x speedup when calling `parse` for repeat calls. `parse` is called hundreds of times on some GitHub pages so this will be welcome improvement.