### PR TITLE
Always call processCallback in constructor.

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -6,9 +6,6 @@ type PartProcessor = (part: TemplatePart, value: unknown) => void
 
 export function createProcessor(processPart: PartProcessor): TemplateTypeInit {
   return {
-    createCallback(instance: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
-      this.processCallback(instance, parts, params)
-    },
     processCallback(_: TemplateInstance, parts: Iterable<TemplatePart>, params: unknown): void {
       if (typeof params !== 'object' || !params) return
       for (const part of parts) {

--- a/src/template-instance.ts
+++ b/src/template-instance.ts
@@ -50,6 +50,7 @@ export class TemplateInstance extends DocumentFragment {
     this.#parts = Array.from(collectParts(this))
     this.#processor = processor
     this.#processor.createCallback?.(this, this.#parts, params)
+    this.#processor.processCallback(this, this.#parts, params)
   }
 
   update(params: unknown): void {

--- a/test/template-instance.js
+++ b/test/template-instance.js
@@ -216,4 +216,84 @@ describe('template-instance', () => {
       })
     })
   })
+
+  describe('custom processors', () => {
+    describe('createCallback', () => {
+      it('is called on construction, if present', () => {
+        const template = document.createElement('template')
+        template.innerHTML = `<div>{{a}}</div>`
+        let createCallCount = 0
+        new TemplateInstance(
+          template,
+          {a: true},
+          {
+            createCallback() {
+              createCallCount += 1
+            },
+            processCallback() {
+              return
+            }
+          }
+        )
+        expect(createCallCount).to.equal(1)
+      })
+
+      it('is not called on update', () => {
+        const template = document.createElement('template')
+        template.innerHTML = `<div>{{a}}</div>`
+        let createCallCount = 0
+        const instance = new TemplateInstance(
+          template,
+          {a: true},
+          {
+            createCallback() {
+              createCallCount += 1
+            },
+            processCallback() {
+              return
+            }
+          }
+        )
+        expect(createCallCount).to.equal(1)
+        instance.update({a: false})
+        expect(createCallCount).to.equal(1)
+      })
+    })
+
+    describe('createCallback', () => {
+      it('is called on construction, if present', () => {
+        const template = document.createElement('template')
+        template.innerHTML = `<div>{{a}}</div>`
+        let processCallCount = 0
+        new TemplateInstance(
+          template,
+          {a: true},
+          {
+            processCallback() {
+              processCallCount += 1
+            }
+          }
+        )
+        expect(processCallCount).to.equal(1)
+      })
+
+      it('is called on update', () => {
+        const template = document.createElement('template')
+        template.innerHTML = `<div>{{a}}</div>`
+        let processCallCount = 0
+        const instance = new TemplateInstance(
+          template,
+          {a: true},
+          {
+            processCallback() {
+              processCallCount += 1
+            }
+          }
+        )
+        expect(processCallCount).to.equal(1)
+        instance.update({a: false})
+        expect(processCallCount).to.equal(2)
+      })
+    })
+  })
 })

--- a/test/template-instance.js
+++ b/test/template-instance.js
@@ -219,7 +219,7 @@ describe('template-instance', () => {
 
   describe('custom processors', () => {
     describe('createCallback', () => {
-      it('is called on construction, if present', () => {
+      it('is called once on construction, if present', () => {
         const template = document.createElement('template')
         template.innerHTML = `<div>{{a}}</div>`
         let createCallCount = 0
@@ -260,8 +260,8 @@ describe('template-instance', () => {
       })
     })
 
-    describe('createCallback', () => {
-      it('is called on construction, if present', () => {
+    describe('processCallback', () => {
+      it('is called on construction', () => {
         const template = document.createElement('template')
         template.innerHTML = `<div>{{a}}</div>`
         let processCallCount = 0


### PR DESCRIPTION
This more closely follows the spec, which always unconditionally calls `processCallback`, only calling `createCallback` if present.

```
9. If there is a _template create callback_ associated with the context object:
    1. Let *createCallback* be `TemplateProcessCallback` associated with the context object.
    2. Invoke [[[Call]]](https://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist) internal method of *createCallback* with *instance*, *partArray*, and *state*.
    3. If the previous step resulted in [abrupt completion](https://tc39.github.io/ecma262/#sec-completion-record-specification-type), return null.
10. Let *processCallback* be the template process callback associated with the context object.
11. Invoke [[[Call]]](https://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist) internal method of *processCallback* with *instance*, *partArray*, and *state*.
```

Fixes #40 refs #41 

