### PR TITLE
refactor parser to catch many edge cases

### DIFF
--- a/src/template-string-parser.ts
+++ b/src/template-string-parser.ts
@@ -14,27 +14,48 @@ export type Token = StringToken | PartToken
 const mem = new Map<string, readonly Token[]>()
 export function parse(text: string): readonly Token[] {
   if (mem.has(text)) return mem.get(text)!
-  let value = ''
+  const length = text.length
+  let lastPos = 0
   let tokenStart = 0
-  let open = false
+  let open = 0
   const items: Token[] = []
-  for (let i = 0; i < text.length; i += 1) {
-    if (text[i] === '{' && text[i + 1] === '{' && text[i - 1] !== '\\' && !open) {
-      open = true
-      if (value) items.push(Object.freeze({type: 'string', start: tokenStart, end: i, value}))
-      value = '{{'
-      tokenStart = i
-      i += 2
-    } else if (text[i] === '}' && text[i + 1] === '}' && text[i - 1] !== '\\' && open) {
-      open = false
-      items.push(Object.freeze({type: 'part', start: tokenStart, end: i + 2, value: value.slice(2).trim()}))
-      value = ''
-      i += 2
-      tokenStart = i
+  for (let i = 0; i < length; i += 1) {
+    const char = text[i]
+    const lookAhead = text[i + 1]
+    const lookBehind = text[i - 1]
+    if (char === '{' && lookAhead === '{' && lookBehind !== '\\') {
+      open += 1
+      if (open === 1) tokenStart = i
+      i += 1
+    } else if (char === '}' && lookAhead === '}' && lookBehind !== '\\' && open) {
+      open -= 1
+      if (open === 0) {
+        if (tokenStart > lastPos) {
+          items.push(
+            Object.freeze({
+              type: 'string',
+              start: lastPos,
+              end: tokenStart,
+              value: text.slice(lastPos, tokenStart)
+            })
+          )
+          lastPos = tokenStart
+        }
+        items.push(
+          Object.freeze({
+            type: 'part',
+            start: tokenStart,
+            end: i + 2,
+            value: text.slice(lastPos + 2, i).trim()
+          })
+        )
+        i += 1
+        lastPos = i + 1
+      }
     }
-    value += text[i] || ''
   }
-  if (value) items.push(Object.freeze({type: 'string', start: tokenStart, end: text.length, value}))
+  if (lastPos < length)
+    items.push(Object.freeze({type: 'string', start: lastPos, end: length, value: text.slice(lastPos, length)}))
   mem.set(text, Object.freeze(items))
   return mem.get(text)!
 }

--- a/test/template-string-parser.js
+++ b/test/template-string-parser.js
@@ -1,48 +1,155 @@
 import {parse} from '../lib/template-string-parser.js'
+chai.config.truncateThreshold = Infinity
 
-describe('template-string-parser', () => {
-  it('extracts `{{}}` surrounding parts as part tokens', () => {
-    expect(Array.from(parse('{{x}}'))).to.eql([{type: 'part', start: 0, end: 5, value: 'x'}])
+function parserTest(message, ...tests) {
+  describe(message, () => {
+    for (let i = 0; i < tests.length; i += 2) {
+      it(tests[i], () => {
+        const output = parse(tests[i])
+        let n = 0
+        for (const token of output) {
+          expect(token)
+            .to.have.property('type')
+            .match(/^(part|string)$/)
+          expect(token).to.have.property('start', n)
+          expect(token).to.have.property('end').gte(n)
+          n = token.end
+        }
+        expect(output).to.eql(tests[i + 1])
+      })
+    }
   })
+}
 
-  it('tokenizes a template string successfully', () => {
-    expect(Array.from(parse('hello {{x}}'))).to.eql([
-      {type: 'string', start: 0, end: 6, value: 'hello '},
-      {type: 'part', start: 6, end: 11, value: 'x'}
-    ])
-  })
+describe.only('template-string-parser', () => {
+  parserTest('extracts `{{}}` surrounding parts as part tokens', '{{x}}', [
+    {type: 'part', start: 0, end: 5, value: 'x'}
+  ])
 
-  it('does not turn escaped `{{`s into expression tokens', () => {
-    expect(Array.from(parse('\\{{x}}'))).to.eql([{type: 'string', start: 0, end: 6, value: '\\{{x}}'}])
-  })
+  parserTest('tokenizes a template string successfully', 'hello {{x}}', [
+    {type: 'string', start: 0, end: 6, value: 'hello '},
+    {type: 'part', start: 6, end: 11, value: 'x'}
+  ])
 
-  it('does not terminate expressions with escaped `}}`s', () => {
-    expect(Array.from(parse('{{x\\}}}'))).to.eql([{type: 'part', start: 0, end: 7, value: 'x\\}'}])
-    expect(Array.from(parse('{{x\\}\\}}}'))).to.eql([{type: 'part', start: 0, end: 9, value: 'x\\}\\}'}])
-  })
-
-  it('strips leading and trailing whitespace', () => {
-    expect(Array.from(parse('{{ x }}'))).to.eql([{type: 'part', start: 0, end: 7, value: 'x'}])
-  })
-
-  it('tokenizes multiple values', () => {
-    expect(Array.from(parse('hello {{x}} and {{y}}'))).to.eql([
+  parserTest(
+    'tokenizes multiple values',
+    'hello {{x}} and {{y}}',
+    [
       {type: 'string', start: 0, end: 6, value: 'hello '},
       {type: 'part', start: 6, end: 11, value: 'x'},
       {type: 'string', start: 11, end: 16, value: ' and '},
       {type: 'part', start: 16, end: 21, value: 'y'}
-    ])
-  })
-
-  it('ignores single braces', () => {
-    expect(Array.from(parse('hello ${world?}'))).to.eql([{type: 'string', start: 0, end: 15, value: 'hello ${world?}'}])
-  })
-
-  it('ignores mismatching parens, treating them as text', () => {
-    expect(Array.from(parse('hello {{'))).to.eql([
+    ],
+    'hello {{x}} and {{y}}!',
+    [
       {type: 'string', start: 0, end: 6, value: 'hello '},
-      {type: 'string', start: 6, end: 8, value: '{{'}
-    ])
-    expect(Array.from(parse('hello }}'))).to.eql([{type: 'string', start: 0, end: 8, value: 'hello }}'}])
-  })
+      {type: 'part', start: 6, end: 11, value: 'x'},
+      {type: 'string', start: 11, end: 16, value: ' and '},
+      {type: 'part', start: 16, end: 21, value: 'y'},
+      {type: 'string', start: 21, end: 22, value: '!'}
+    ]
+  )
+
+  parserTest(
+    'tokenizes consecutive values',
+    'hello {{x}}{{y}}',
+    [
+      {type: 'string', start: 0, end: 6, value: 'hello '},
+      {type: 'part', start: 6, end: 11, value: 'x'},
+      {type: 'part', start: 11, end: 16, value: 'y'}
+    ],
+    '{{x}}{{y}}{{z}}',
+    [
+      {type: 'part', start: 0, end: 5, value: 'x'},
+      {type: 'part', start: 5, end: 10, value: 'y'},
+      {type: 'part', start: 10, end: 15, value: 'z'}
+    ],
+    'abc{{def}}{{ghi}}{{jkl}}{{mno}}{{pqr}}{{stu}}vwxyz',
+    [
+      {type: 'string', start: 0, end: 3, value: 'abc'},
+      {type: 'part', start: 3, end: 10, value: 'def'},
+      {type: 'part', start: 10, end: 17, value: 'ghi'},
+      {type: 'part', start: 17, end: 24, value: 'jkl'},
+      {type: 'part', start: 24, end: 31, value: 'mno'},
+      {type: 'part', start: 31, end: 38, value: 'pqr'},
+      {type: 'part', start: 38, end: 45, value: 'stu'},
+      {type: 'string', start: 45, end: 50, value: 'vwxyz'}
+    ]
+  )
+
+  parserTest('does not turn escaped `{{`s into expression tokens', '\\{{x}}', [
+    {type: 'string', start: 0, end: 6, value: '\\{{x}}'}
+  ])
+
+  parserTest('strips leading and trailing whitespace', '{{ x }}', [{type: 'part', start: 0, end: 7, value: 'x'}])
+
+  parserTest(
+    'correctly deals with trailing strings',
+    '{{ x }}!',
+    [
+      {type: 'part', start: 0, end: 7, value: 'x'},
+      {type: 'string', start: 7, end: 8, value: '!'}
+    ],
+    'hello {{x}}!',
+    [
+      {type: 'string', start: 0, end: 6, value: 'hello '},
+      {type: 'part', start: 6, end: 11, value: 'x'},
+      {type: 'string', start: 11, end: 12, value: '!'}
+    ]
+  )
+
+  parserTest(
+    'does not terminate expressions with escaped `}}`s',
+    '{{x\\}}}',
+    [{type: 'part', start: 0, end: 7, value: 'x\\}'}],
+    '{{x\\}\\}}}',
+    [{type: 'part', start: 0, end: 9, value: 'x\\}\\}'}],
+    '{{x\\}}',
+    [{type: 'string', start: 0, end: 6, value: '{{x\\}}'}],
+    '\\{{x}}',
+    [{type: 'string', start: 0, end: 6, value: '\\{{x}}'}]
+  )
+
+  parserTest('ignores single braces', 'hello ${world?}', [
+    {type: 'string', start: 0, end: 15, value: 'hello ${world?}'}
+  ])
+
+  parserTest(
+    'ignores mismatching parens, treating them as text',
+    'hello }}',
+    [{type: 'string', start: 0, end: 8, value: 'hello }}'}],
+    'hello {{',
+    [{type: 'string', start: 0, end: 8, value: 'hello {{'}],
+    'hello {{{{',
+    [{type: 'string', start: 0, end: 10, value: 'hello {{{{'}],
+    'hello {{}{',
+    [{type: 'string', start: 0, end: 10, value: 'hello {{}{'}],
+    'hello }}{{}',
+    [{type: 'string', start: 0, end: 11, value: 'hello }}{{}'}]
+  )
+
+  parserTest('ignores nested parens, treating them as text', '{{ "Your balance: {{ balance }}" }}', [
+    {type: 'part', start: 0, end: 35, value: '"Your balance: {{ balance }}"'}
+  ])
+
+  parserTest(
+    'parses awkward inputs correctly',
+    '{x{{}}}',
+    [
+      {type: 'string', start: 0, end: 2, value: '{x'},
+      {type: 'part', start: 2, end: 6, value: ''},
+      {type: 'string', start: 6, end: 7, value: '}'}
+    ],
+    '{{{x}}}',
+    [
+      {type: 'part', start: 0, end: 6, value: '{x'},
+      {type: 'string', start: 6, end: 7, value: '}'}
+    ],
+    '{}{{x}}}',
+    [
+      {type: 'string', start: 0, end: 2, value: '{}'},
+      {type: 'part', start: 2, end: 7, value: 'x'},
+      {type: 'string', start: 7, end: 8, value: '}'}
+    ]
+  )
 })


### PR DESCRIPTION
This drastically refactors the `parse` function to handle edge cases much better. 

Should fix #38 and fix #44 /cc @dy 

It should be noted that this is a _full deviation_ from the [spec that exists in the proposal](https://github.com/WICG/webcomponents/blob/159b1600bab02fe9cd794825440a98537d53b389/proposals/Template-Instantiation.md#43-creating-template-parts) but I believe that's a good thing. I think the spec in the proposal has bugs, and I think practically speaking we need to deviate, and provide feedback to the proposal committee. To identify these areas. 

I'm quite happy with these changes but I'd like to get feedback from @dy, as well as @github/ui-frameworks-reviewers  