### PR TITLE
Fix Safari runtime error for..of weirdness

### DIFF
--- a/src/template-instance.ts
+++ b/src/template-instance.ts
@@ -25,7 +25,9 @@ function* collectParts(el: DocumentFragment): Generator<TemplatePart> {
         }
       }
     } else if (node instanceof Text && node.textContent && node.textContent.includes('{{')) {
-      for (const token of parse(node.textContent)) {
+      const parsed = parse(node.textContent)
+      for (let i = 0; i < parsed.length; i += 1) {
+        const token = parsed[i]
         if (token.end < node.textContent.length) node.splitText(token.end)
         if (token.type === 'part') yield new NodeTemplatePart(node, token.value)
         break

--- a/src/template-instance.ts
+++ b/src/template-instance.ts
@@ -26,6 +26,8 @@ function* collectParts(el: DocumentFragment): Generator<TemplatePart> {
       }
     } else if (node instanceof Text && node.textContent && node.textContent.includes('{{')) {
       const parsed = parse(node.textContent)
+      // A for..of loop would be nicer here, unfortunately Safari had a runtime error on this loop.
+      // https://github.com/github/template-parts/pull/55
       for (let i = 0; i < parsed.length; i += 1) {
         const token = parsed[i]
         if (token.end < node.textContent.length) node.splitText(token.end)


### PR DESCRIPTION
We've been using template-parts in our new video player project over at Mux. 
We really like it with the added utilities of jtml! 

Today we ran into a rather strange runtime error only in Safari and it only happens when the web inspector is not open.
Try loading this page with and without web inspector open, might need a few reloads:
https://elements-demo-nextjs-git-fork-luwes-better-errors-mux.vercel.app/MuxPlayer

1. Without web inspector open, the video player layout sometimes doesn't look good, the layout of icons and buttons are wrong.
2. If you then open the web inspector you see a type error like

```js
TypeError: e of xr is not a function. (In 'e of xr(t.textContent)', 'e of xr' is undefined)
```
This refers to this line:
https://github.com/github/template-parts/blob/main/src/template-instance.ts#L28

I don't think the code is wrong here but Safari definitely misinterprets it somehow.
Changing the for..of loop to a regular for loop fixes the issue,
I also tried to store the result of the parse() function in a variable first and use the for..of loop but that didn't fix it :(


![SCR-20220325-d8k](https://user-images.githubusercontent.com/360826/160192292-9b46da01-f11c-49c0-a1da-2325d503c225.png) 

![SCR-20220325-dye](https://user-images.githubusercontent.com/360826/160218511-aa18fd46-db23-4788-ab6e-fb6e47d83ba4.png)


Mac OS 12.3
Safari 15.4 