### PR TITLE
Export `InnerTemplatePart`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {TemplateInstance} from './template-instance.js'
 export {parse} from './template-string-parser.js'
 export {AttributeTemplatePart, AttributeValueSetter} from './attribute-template-part.js'
+export {InnerTemplatePart} from './inner-template-part.js'
 export {NodeTemplatePart} from './node-template-part.js'
 export {
   createProcessor,

--- a/test/template-instance.ts
+++ b/test/template-instance.ts
@@ -1,8 +1,12 @@
 import {expect} from '@open-wc/testing'
-import {TemplateInstance} from '../src/template-instance'
-import {NodeTemplatePart} from '../src/node-template-part'
-import {InnerTemplatePart} from '../src/inner-template-part'
-import {processPropertyIdentity, propertyIdentityOrBooleanAttribute, createProcessor} from '../src/processors'
+import {
+  TemplateInstance,
+  NodeTemplatePart,
+  InnerTemplatePart,
+  processPropertyIdentity,
+  propertyIdentityOrBooleanAttribute,
+  createProcessor,
+} from '../src/index'
 
 describe('template-instance', () => {
   it('applies data to templated text nodes', () => {


### PR DESCRIPTION
Add an entry to the `src/index.ts` to export the new `InnerTemplatePart`.

Since consumers are most likely to import `TemplateInstance`, change the `test/template-instance.ts` test file to import properties from the module in a way that more closely resembles the end-user consumer experience.