### PR TITLE
Update CODEOWNERS to Web Systems

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/primer-reviewers
+* @github/web-systems-reviewers


### PR DESCRIPTION
Updates CODEOWNERS from Primer to Web Systems. `template-parts` is not used within Primer libraries.